### PR TITLE
fix(utils): check for empty filetype on parser detection

### DIFF
--- a/lua/ts_utils.lua
+++ b/lua/ts_utils.lua
@@ -105,7 +105,7 @@ end
 
 function M.has_parser(lang)
   local lang = lang or api.nvim_buf_get_option(0, 'filetype')
-  return #api.nvim_get_runtime_file('parser/' .. lang .. '.*', false) > 0
+  return #lang > 0 and #api.nvim_get_runtime_file('parser/' .. lang .. '.*', false) > 0
 end
 
 -- is dest in a parent of source


### PR DESCRIPTION
I was getting this error when open terminal buffers that triggered the highlight auto command.

`vsp term://npm run test:scoped -- --pattern someFile.ts`

![Screen Shot 2020-06-19 at 10 59 50 AM](https://user-images.githubusercontent.com/2062154/85161768-e690ba00-b225-11ea-84e8-10433e27e9a1.png)

This fixed it.