### PR TITLE
fix: api changes on completion-nvim side

### DIFF
--- a/lua/ts_complete.lua
+++ b/lua/ts_complete.lua
@@ -58,8 +58,8 @@ function M.getCompletionItems(prefix, score_func, bufnr)
       item = M.getCompletionItems
     }
 
-    if require'source' then
-      require'source'.addCompleteItems('ts', M.complete_item)
+    if require'completion' then
+      require'completion'.addCompletionSource('ts', M.complete_item)
     end
 
     return M


### PR DESCRIPTION
Just a small changes on completion-nvim side. I'm planning moving `source.lua` to subdirectory and use `completion.lua` as the main api, so before merging that to master I want to make sure your plugin doesn't just break because of it.
Reference: https://github.com/haorenW1025/completion-nvim/pull/121